### PR TITLE
Refactor logMessage.

### DIFF
--- a/xicam/core/msg/__init__.py
+++ b/xicam/core/msg/__init__.py
@@ -208,7 +208,7 @@ def logMessage(*args: Any, level: int = INFO, loggername: str = None, timestamp:
     if loggername is not None:
         warings.warn("Custom loggername is no longer supported, "
                      "ignored.")
-    caller_name = inspect.stack()[1][3]
+    caller_name = sys._getframe().f_back.f_code.co_name
     logger.log(level, message, extra={'caller_name': caller_name})
 
     # Also, print message to stdout
@@ -239,7 +239,7 @@ def logError(exception: Exception, value=None, tb=None, **kwargs):
         tb = exception.__traceback__
     kwargs["level"] = ERROR
     if 'loggername' not in kwargs:
-        kwargs['loggername'] = inspect.stack()[1][3]
+        kwargs['loggername'] = sys._getframe().f_back.f_code.co_name
     logMessage("\n", "The following error was handled safely by Xi-cam. It is displayed here for debugging.", **kwargs)
     try:
         logMessage("\n", *traceback.format_exception(exception, value, tb), **kwargs)

--- a/xicam/core/msg/__init__.py
+++ b/xicam/core/msg/__init__.py
@@ -32,7 +32,7 @@ logger.setLevel('DEBUG')  # minimum level shown
 handler = logging.StreamHandler()
 handler.setLevel('DEBUG')  # minimum level shown
 formatter = logging.Formatter("%(asctime)s - %(name) - %(caller_name)s - "
-                              "%(levelname) %(threadName)d - %(message)s")
+                              "%(levelname) - %(thread)d:%(threadName)s - %(message)s")
 handler.setFormatter(formatter)
 
 # Log levels constants

--- a/xicam/core/msg/__init__.py
+++ b/xicam/core/msg/__init__.py
@@ -34,8 +34,8 @@ logger.setLevel('DEBUG')  # minimum level shown
 handler = logging.StreamHandler()
 handler.setLevel('DEBUG')  # minimum level shown
 #format = "%(asctime)s - %(name)s - %(module)s:%(lineno)d - %(funcName)s - "
-format = "%(asctime)s - %(levelname)s - %(thread)d:%(threadName)s - %(message)s"
-date_format = "%y-%m-%d %H:%M:%S"
+format = "%(asctime)s - %(caller_name)s - %(levelname)s - %(threadName)s - %(message)s"
+date_format = "%a %b %d %H:%M:%S %Y"
 formatter = logging.Formatter(fmt=format, datefmt=date_format)
 handler.setFormatter(formatter)
 logger.addHandler(handler)

--- a/xicam/core/msg/__init__.py
+++ b/xicam/core/msg/__init__.py
@@ -203,7 +203,7 @@ def logMessage(*args: Any, level: int = INFO, loggername: str = None, timestamp:
     """
 
     # Join the args to a string
-    s = " ".join(map(str, args))
+    message = " ".join(map(str, args))
 
     if loggername is not None:
         warings.warn("Custom loggername is no longer supported, "

--- a/xicam/core/msg/__init__.py
+++ b/xicam/core/msg/__init__.py
@@ -5,6 +5,7 @@ import signal
 import sys
 import os
 import time
+import warnings
 from typing import Any
 import traceback
 import threading
@@ -32,9 +33,12 @@ logger = logging.getLogger('xicam')
 logger.setLevel('DEBUG')  # minimum level shown
 handler = logging.StreamHandler()
 handler.setLevel('DEBUG')  # minimum level shown
-formatter = logging.Formatter("%(asctime)s - %(name) - %(caller_name)s - "
-                              "%(levelname) - %(thread)d:%(threadName)s - %(message)s")
+#format = "%(asctime)s - %(name)s - %(module)s:%(lineno)d - %(funcName)s - "
+format = "%(asctime)s - %(levelname)s - %(thread)d:%(threadName)s - %(message)s"
+date_format = "%y-%m-%d %H:%M:%S"
+formatter = logging.Formatter(fmt=format, datefmt=date_format)
 handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 # Log levels constants
 DEBUG = logging.DEBUG  # 10
@@ -206,16 +210,10 @@ def logMessage(*args: Any, level: int = INFO, loggername: str = None, timestamp:
     message = " ".join(map(str, args))
 
     if loggername is not None:
-        warings.warn("Custom loggername is no longer supported, "
+        warnings.warn("Custom loggername is no longer supported, "
                      "ignored.")
     caller_name = sys._getframe().f_back.f_code.co_name
     logger.log(level, message, extra={'caller_name': caller_name})
-
-    # Also, print message to stdout
-    # try:
-    #     if not suppressreprint: print(f'{timestamp} - {loggername} - {levelname} - {s}')
-    # except UnicodeEncodeError:
-    #     print('A unicode string could not be written to console. Some logging will not be displayed.')
 
 
 def clearMessage():

--- a/xicam/core/msg/__init__.py
+++ b/xicam/core/msg/__init__.py
@@ -111,7 +111,7 @@ def hideBusy():
         from .. import threads  # must be a late import
 
         threads.invoke_in_main_thread(progressbar.hide)
-        progressbar.setRange(0, 100)
+        threads.invoke_in_main_thread(progressbar.setRange, 0, 100)
 
 
 # aliases


### PR DESCRIPTION
- Use one logger named 'xicam'. In future any additional loggers should
be named 'xicam.'.
- Attach one handler to that top level logger. All message from logger
named 'xicam.*' will be emitted by that handler. This removes the need
for the blacklist, because we are not adding a handler to the root
    logger.
- Instead of hand-assembling a message string, we rely on a Formatter.
This lets us use threadName and timestamp that the logging framework is
already computing for us rather than doing again ourselves. Importantly,
this string munging is only performed if the message will actually be
emitted by at least one handler, so it will be possible to trade
performance and verbosity. (Currently this requires editing the source
to change the logger and handler minimum levels from "DEBUG" to
something else, but it could be made configurable in the future.)
- Note that we no longer let the caller pass in a custom logger name. If
they try, we ignore them and warn that we have ignored them. This
prevents accumualting an unbounded number of special loggers, which
cannot be garbage collected.
- We do however retain the smart inspection-based code by using the
logging framework's "extra" feature.