### PR TITLE
Increase minimum required databroker.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["databroker>=1.0.0b2", "distributed", "dask"],
+    install_requires=["databroker>=1.0.0b8", "distributed", "dask"],
     setup_requires=[],
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
We could just ban the broken release (1.0.0b7) but I don't think there is any
harm in requiring the latest one to get fast performance.