### PR TITLE
Cleanup implementation of sniffer heuristics

### DIFF
--- a/xicam/core/data/__init__.py
+++ b/xicam/core/data/__init__.py
@@ -22,7 +22,7 @@ def detect_mimetypes(filename: str) -> List[str]:
     matched_mimetypes = list()
 
     if Path(filename).is_dir():
-        return None  # TODO: do directories have mime-type?
+        return matched_mimetypes  # TODO: do directories have mime-type?
 
     with open(filename, 'rb') as file:
         # The choice of 64 bytes is arbitrary. We may increase this in the
@@ -58,7 +58,12 @@ def applicable_ingestors(filename, mimetype):
     ingestors = []
     for ep in entrypoints.get_group_all('intake.catalogs'):
         if ep.name == mimetype:
-            ingestors.append(ep.load())
+            try:
+                ingestor = ep.load()
+            except Exception as ex:
+                msg.logError(ex)
+            else:
+                ingestors.append(ingestor)
 
     return ingestors
 

--- a/xicam/core/data/__init__.py
+++ b/xicam/core/data/__init__.py
@@ -30,11 +30,14 @@ def detect_mimetypes(filename: str) -> List[str]:
         # assume that they will receive this exact number of bytes.
         first_bytes = file.read(64)
     for ep in entrypoints.get_group_all('databroker.sniffers'):
-        content_sniffer = ep.load()
-
-        matched_mimetype = content_sniffer(filename, first_bytes)
-        if matched_mimetype:
-            matched_mimetypes.append(matched_mimetype)
+        try:
+            content_sniffer = ep.load()  # TODO: only load sniffers once
+        except Exception as ex:
+            msg.logError(ex)
+        else:
+            matched_mimetype = content_sniffer(filename, first_bytes)
+            if matched_mimetype:
+                matched_mimetypes.append(matched_mimetype)
 
     # Guessing the mimetype from the mimemtype db is quick, lets do it always
     matched_mimetype = mimetypes.guess_type(filename)[0]

--- a/xicam/core/data/__init__.py
+++ b/xicam/core/data/__init__.py
@@ -37,7 +37,9 @@ def detect_mimetypes(filename: str) -> List[str]:
             matched_mimetypes.append(matched_mimetype)
 
     # Guessing the mimetype from the mimemtype db is quick, lets do it always
-    matched_mimetypes.append(mimetypes.guess_type(filename)[0])
+    matched_mimetype = mimetypes.guess_type(filename)[0]
+    if matched_mimetype:
+        matched_mimetypes.append(matched_mimetype)
 
     if not matched_mimetypes:
         raise UnknownFileType(f"Could not identify the MIME type of {filename}")

--- a/xicam/core/data/__init__.py
+++ b/xicam/core/data/__init__.py
@@ -53,7 +53,7 @@ def applicable_ingestors(filename, mimetype):
     """
     # Find ingestor(s) for this mimetype.
     ingestors = []
-    for ep in entrypoints.get_group_all('intake.catalogs'):
+    for ep in entrypoints.get_group_all('databroker.ingestors'):
         if ep.name == mimetype:
             try:
                 ingestor = ep.load()


### PR DESCRIPTION
These heuristics in use at https://github.com/Xi-CAM/Xi-cam.NCEM/pull/6

Limitations:
By design, a file extension may have only one mimetype associated with it on all platforms. The API for querying the `mimetypes` database and the structure of its internal cache reflects this. In a case where two disparate techniques want to assign different mimetypes to the same extension, one of these mimetypes would then never be discoverable. To circumvent this limitation, both techniques would have to implement sniffers, so that sniffer mechanism preempts the need to query `mimetypes`.